### PR TITLE
Saiga crash fix

### DIFF
--- a/mods/DMCWO/lua/Extra/useable_drums.lua
+++ b/mods/DMCWO/lua/Extra/useable_drums.lua
@@ -26,11 +26,21 @@ local old_saiga_init = WeaponFactoryTweakData._init_saiga
 	
 function WeaponFactoryTweakData:_init_saiga()
 	old_saiga_init(self)
-	self.parts.wpn_upg_saiga_m_20rnd.pcs = {
-			20,
-			30,
-			40
+	self.parts.wpn_upg_saiga_m_20rnd = {
+		pcs = {20, 30, 40},
+		type = "magazine",
+		name_id = "bm_wp_saiga_m_20rnd",
+		a_obj = "a_m",
+		unit = "units/payday2/weapons/wpn_fps_shot_saiga_pts/wpn_upg_saiga_m_20rnd",
+		stats = {value = 1, extra_ammo = 6},
+		animations = {
+			reload = "reload",
+			reload_not_empty = "reload_not_empty"
 		}
+	}
+	
+	self.parts.wpn_upg_saiga_m_20rnd.third_unit = "units/payday2/weapons/wpn_third_shot_saiga_pts/wpn_third_saiga_m_20rnd"
+	table.insert(self.wpn_fps_shot_saiga.uses_parts, "wpn_upg_saiga_m_20rnd")
 end
 
 local old_ak_init = WeaponFactoryTweakData._init_ak_parts

--- a/mods/DMCWO/lua/Extra/useable_drums.lua
+++ b/mods/DMCWO/lua/Extra/useable_drums.lua
@@ -27,7 +27,11 @@ local old_saiga_init = WeaponFactoryTweakData._init_saiga
 function WeaponFactoryTweakData:_init_saiga()
 	old_saiga_init(self)
 	self.parts.wpn_upg_saiga_m_20rnd = {
-		pcs = {20, 30, 40},
+		pcs = {
+				20,
+				30,
+				40
+			},
 		type = "magazine",
 		name_id = "bm_wp_saiga_m_20rnd",
 		a_obj = "a_m",


### PR DESCRIPTION
Fix crash from missing Saiga attachment, removed internally in Update 100, code added to DMCWO to prevent crash.
